### PR TITLE
fix u-syndication class for bridgy publish links

### DIFF
--- a/rel-syndication.php
+++ b/rel-syndication.php
@@ -28,7 +28,7 @@ function add_js_rel_syndication($content) {
 	}
 
 	if ($see_on !== ""){
-		$content = $content . '<div class="u-syndication">' . __("Also on:", "rel-syndication") . $see_on . "</div>";
+		$content = $content . '<div class="syndication">' . __("Also on:", "rel-syndication") . $see_on . "</div>";
 	}
 	// Returns the content.
 	return $content;
@@ -194,7 +194,7 @@ function store_bridgy_publish_link($response, $source, $target, $post_ID) {
 	$json = json_decode(wp_remote_retrieve_body($response));
 	if (!is_wp_error($response) && $json && $json->url &&
 		preg_match('~https?://(?:www\.)?(brid.gy|localhost:8080)/publish/(.*)~', $target, $matches)) {
-		$link = '<a href="' . $json->url . '">' . ucfirst($matches[2]) . '</a>';
+		$link = '<a class="u-syndication" href="' . $json->url . '">' . ucfirst($matches[2]) . '</a>';
 		$existing = get_post_custom_values('bridgy_publish_syndication_urls', $post_ID);
 		if (array_search($link, get_post_custom_values('bridgy_publish_syndication_urls', $post_ID)) == false) {
 			add_post_meta($post_ID, 'bridgy_publish_syndication_urls', $link);


### PR DESCRIPTION
u-\* classes belong on link elements, not divs

thanks @kylewm for noticing this!
